### PR TITLE
Fix: Resolved Crash caused by FBI killing Domain, changed scraping to…

### DIFF
--- a/src/scraper.lua
+++ b/src/scraper.lua
@@ -3,7 +3,7 @@ local Api = require('zlibrary.api')
 
 -- Cache configuration
 local CACHE_FILE = "annas_domains_cache.txt"
-local CACHE_DURATION = 2 * 24 * 60 * 60  -- 2 days in seconds
+local CACHE_DURATION = 12 * 60 * 60  -- 12 hours in seconds
 
 -- Reads domains from cache
 local function read_cache()
@@ -134,10 +134,11 @@ local function get_annas_archive_domains()
     -- Fallback: default domains if Wikipedia fails
     print("=== Warning: Using fallback domains")
     return {
+        "annas-archive.li",
+        "annas-archive.gl",
         "annas-archive.org",
         "annas-archive.se",
         "annas-archive.gs",
-        "annas-archive.li",
         "annas-archive.pm",
         "annas-archive.in",
     }
@@ -616,10 +617,13 @@ end
 function download_book(book, path)
     -- Try different Library Genesis mirrors
     local lgli_exts = {
-        [1] = ".li/",
-        [2] = ".is/",
-        [3] = ".rs/",
-        [4] = ".st/",
+        ".la/",
+        ".gl/",
+        ".li/",
+        ".is/",
+        ".rs/",
+        ".st/",
+        ".bz/",
     }
 
     for _, lgli_ext in ipairs(lgli_exts) do


### PR DESCRIPTION
… include current domains.
Tested on my Kindle Paperwhite 12 gen, works again. Before it crashed KOReader.
Actually now not sure if needed, i tested before with the last release from october, but in the timeline now i saw that 2 weeks ago already a new change was made. Still, added one additional domain .gl, and changed the recovery time for cache to 12 hours instead of 2 days.