### PR TITLE
Changed variable names to make this plugin compatible with Zlib plugin

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -31,7 +31,7 @@ local Zlibrary = WidgetContainer:extend{
 }
 
 function Zlibrary:onDispatcherRegisterActions()
-    Dispatcher:registerAction("zlibrary_search", { category="none", event="ZlibrarySearch", title=T("Z-library search"), general=true,})
+    Dispatcher:registerAction("annas_search", { category="none", event="ZlibrarySearch", title=T("Z-library search"), general=true,})
 end
 
 function Zlibrary:init()
@@ -59,7 +59,7 @@ function Zlibrary:init()
 
 end
 
-function Zlibrary:onZlibrarySearch()
+function Zlibrary:onAnnasSearch()
     local def_search_input
     if self.ui and self.ui.doc_settings and self.ui.doc_settings.data.doc_props then
       local doc_props = self.ui.doc_settings.data.doc_props
@@ -72,7 +72,7 @@ end
 function Zlibrary:addToMainMenu(menu_items)
 
     if not self.ui.view then
-        menu_items.zlibrary_main = {
+        menu_items.annas_main = {
             sorting_hint = "search",
             text = T("Anna's Archive"),
             callback = function()


### PR DESCRIPTION
Changed a few variables to a unique name so that the Zlib plugin and this one are compatible on the same device. Before this change the Zlib plugin would overwrite the actions since they had the same name. Really simple change.